### PR TITLE
Fix show access checks in RPCs

### DIFF
--- a/supabase/migrations/20250918151741_storage_metadata_enforcement.sql
+++ b/supabase/migrations/20250918151741_storage_metadata_enforcement.sql
@@ -39,7 +39,7 @@ BEGIN
     IF NOT EXISTS (
       SELECT 1 FROM advancing_sessions s
       WHERE s.id = p_session_id 
-        AND (is_org_member(s.org_id) OR has_show_access(s.show_id, current_user_id))
+        AND (is_org_member(s.org_id) OR has_show_access(s.show_id, 'edit'))
     ) THEN
       RAISE EXCEPTION 'No permission to upload to this session';
     END IF;

--- a/supabase/migrations/20250918152121_edge_function_hardening.sql
+++ b/supabase/migrations/20250918152121_edge_function_hardening.sql
@@ -241,7 +241,7 @@ BEGIN
   END IF;
 
   -- Verify user has access to the show
-  IF NOT has_show_access(p_show_id, current_user_id) THEN
+  IF NOT has_show_access(p_show_id, 'edit') THEN
     RAISE EXCEPTION 'Access denied to show';
   END IF;
 
@@ -294,7 +294,7 @@ BEGIN
   END IF;
 
   -- Verify user has access to invite to this show
-  IF NOT has_show_access(p_show_id, current_user_id) THEN
+  IF NOT has_show_access(p_show_id, 'edit') THEN
     RAISE EXCEPTION 'Access denied to show';
   END IF;
 


### PR DESCRIPTION
## Summary
- ensure new RPCs call `has_show_access` with the expected role string so they respect existing collaborator permissions
- keep the enforced upload check aligned with edit-level permissions required for advancing session work

## Testing
- npm run lint (warnings about unused imports already present)


------
https://chatgpt.com/codex/tasks/task_b_68cc3bff6b208327a7a6e31568d00af0