### PR TITLE
Align storage verification helper with files schema

### DIFF
--- a/supabase/functions/verify-storage/verification.sql
+++ b/supabase/functions/verify-storage/verification.sql
@@ -1,52 +1,53 @@
 -- Post-upload verification function
--- Alternative to Edge Function: verifies storage metadata matches database records
-CREATE OR REPLACE FUNCTION verify_storage_metadata()
+-- Cross-checks storage metadata expectations for recently uploaded files
+CREATE OR REPLACE FUNCTION verify_storage_metadata(hours_back int DEFAULT 1)
 RETURNS TABLE (
   file_id uuid,
   storage_path text,
-  metadata_mismatch jsonb,
-  action_required text
+  expected_metadata jsonb,
+  verification_status text,
+  requires_edge_function boolean
 )
 LANGUAGE plpgsql
 SECURITY DEFINER
 AS $$
-DECLARE
-  file_record RECORD;
-  storage_object RECORD;
-  expected_metadata jsonb;
-  actual_metadata jsonb;
 BEGIN
-  -- Check all files uploaded in the last hour for metadata consistency
-  FOR file_record IN 
-    SELECT f.id, f.storage_path, f.bucket_name, f.org_id, f.session_id, f.uploaded_by
-    FROM files f
-    WHERE f.created_at > NOW() - INTERVAL '1 hour'
-  LOOP
-    -- Get storage object metadata (this would need to be done via a function that calls storage API)
-    -- For now, we'll return a template for what needs to be verified
-    
-    expected_metadata := jsonb_build_object(
-      'org_id', file_record.org_id,
-      'uploaded_by', file_record.uploaded_by,
-      'verified', true
-    );
-    
-    -- TODO: Implement actual storage metadata retrieval
-    -- This would require calling Supabase Storage API to get object metadata
-    actual_metadata := jsonb_build_object('placeholder', 'needs_storage_api_integration');
-    
-    -- For now, return files that need verification
-    RETURN QUERY SELECT 
-      file_record.id,
-      file_record.storage_path,
+  RETURN QUERY
+  WITH file_expectations AS (
+    SELECT
+      f.id,
+      f.storage_path,
       jsonb_build_object(
-        'expected', expected_metadata,
-        'actual', actual_metadata
-      ),
-      'verify_metadata'::text;
-  END LOOP;
-  
-  RETURN;
+        'org_id', f.org_id,
+        'uploaded_by', f.uploaded_by,
+        'upload_timestamp', extract(epoch FROM f.created_at),
+        'verified', true
+      )
+      || CASE WHEN f.session_id IS NOT NULL THEN jsonb_build_object('session_id', f.session_id) ELSE '{}'::jsonb END
+      || CASE WHEN s.show_id IS NOT NULL THEN jsonb_build_object('show_id', s.show_id) ELSE '{}'::jsonb END
+      || CASE
+          WHEN af.party_type IS NOT NULL THEN jsonb_build_object('party_type', af.party_type)
+          WHEN ad.party_type IS NOT NULL THEN jsonb_build_object('party_type', ad.party_type)
+          ELSE '{}'::jsonb
+         END AS metadata_json,
+      CASE
+        WHEN f.created_at > NOW() - INTERVAL '1 hour' * hours_back THEN 'needs_storage_api_verification'
+        ELSE 'verification_window_expired'
+      END AS status
+    FROM files f
+    LEFT JOIN advancing_sessions s ON s.id = f.session_id
+    LEFT JOIN advancing_fields af ON af.id = f.field_id
+    LEFT JOIN advancing_documents ad ON ad.id = f.document_id
+    WHERE f.created_at > NOW() - INTERVAL '1 hour' * hours_back
+      AND is_org_member(f.org_id)
+  )
+  SELECT
+    id,
+    storage_path,
+    metadata_json,
+    status,
+    true AS requires_edge_function
+  FROM file_expectations;
 END;
 $$;
 
@@ -64,10 +65,10 @@ BEGIN
   -- 1. List all objects in storage buckets
   -- 2. Compare with database records
   -- 3. Remove orphaned objects or create missing database records
-  
+
   -- For now, just clean up database records without storage objects
   -- (This would need integration with storage API to verify existence)
-  
+
   RETURN orphan_count;
 END;
 $$;


### PR DESCRIPTION
## Summary
- update the verify_storage_metadata helper to rely only on existing public.files columns and emit the enforced metadata shape used by uploads
- derive optional session, show, and party context directly from advancing tables and surface the verification status/edge-function requirement
- document the storage verification contract so the edge function and SQL helper share the same expectations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cc3bfffb9c832797bb8844e1c38045