### PR TITLE
Fix advancing session RPC to use current schema

### DIFF
--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -767,8 +767,8 @@ export type Database = {
       app_create_advancing_session: {
         Args: {
           p_show_id: string
-          p_session_name: string
-          p_session_date?: string
+          p_session_title: string
+          p_expires_at?: string
         }
         Returns: string
       }

--- a/supabase/migrations/20250918152121_edge_function_hardening.sql
+++ b/supabase/migrations/20250918152121_edge_function_hardening.sql
@@ -223,8 +223,8 @@ $$;
 -- Function to create advancing session with logging
 CREATE OR REPLACE FUNCTION app_create_advancing_session(
   p_show_id uuid,
-  p_session_name text,
-  p_session_date date DEFAULT NULL
+  p_session_title text,
+  p_expires_at timestamptz DEFAULT NULL
 )
 RETURNS uuid
 LANGUAGE plpgsql  
@@ -251,8 +251,8 @@ BEGIN
   WHERE s.id = p_show_id;
 
   -- Create the advancing session
-  INSERT INTO advancing_sessions (show_id, name, session_date, created_by)
-  VALUES (p_show_id, p_session_name, p_session_date, current_user_id)
+  INSERT INTO advancing_sessions (show_id, title, expires_at, created_by)
+  VALUES (p_show_id, p_session_title, p_expires_at, current_user_id)
   RETURNING id INTO session_id;
 
   -- Log session creation
@@ -262,8 +262,8 @@ BEGIN
     'advancing_session',
     session_id,
     jsonb_build_object(
-      'session_name', p_session_name,
-      'session_date', p_session_date,
+      'session_title', p_session_title,
+      'expires_at', p_expires_at,
       'show_id', p_show_id,
       'created_by', current_user_id
     )


### PR DESCRIPTION
## Summary
- update `app_create_advancing_session` to insert into the existing `title`/`expires_at` columns and log matching metadata keys
- refresh the generated Supabase client types so the RPC arguments mirror the adjusted function signature

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cc3bfea7708327b220dbd2c7a47cbf