### PR TITLE
Refactor show detail view into modular typed composition

### DIFF
--- a/app/(app)/[org]/shows/[showId]/components/AdvancingSessionsCard.tsx
+++ b/app/(app)/[org]/shows/[showId]/components/AdvancingSessionsCard.tsx
@@ -1,0 +1,54 @@
+import Link from 'next/link'
+import { FileText } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+
+import type { AdvancingSession } from '../types'
+import { formatDate, formatDateTime } from '../utils'
+
+interface AdvancingSessionsCardProps {
+  sessions: AdvancingSession[]
+  orgSlug: string
+}
+
+export function AdvancingSessionsCard({ sessions, orgSlug }: AdvancingSessionsCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <FileText className="h-4 w-4" />
+          Advancing Sessions
+        </CardTitle>
+        <CardDescription>Link into advancing workflows</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {sessions.length > 0 ? (
+          <ul className="space-y-3">
+            {sessions.map((session) => (
+              <li
+                key={session.id}
+                className="flex items-center justify-between gap-3 rounded-md border border-muted bg-card/50 p-3"
+              >
+                <div>
+                  <p className="text-sm font-medium text-foreground">{session.title}</p>
+                  <p className="text-xs text-muted-foreground">
+                    Created {formatDateTime(session.created_at)}
+                    {session.expires_at ? ` • Expires ${formatDate(session.expires_at.split('T')[0])}` : ''}
+                  </p>
+                </div>
+                <Button asChild size="sm" variant="outline">
+                  <Link href={`/${orgSlug}/advancing/${session.id}`}>Open</Link>
+                </Button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            No advancing session yet. Create one to start collaborating with promoters.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/(app)/[org]/shows/[showId]/components/CollaborationCard.tsx
+++ b/app/(app)/[org]/shows/[showId]/components/CollaborationCard.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link'
+import { FileText, Users } from 'lucide-react'
+
+import { InviteCollaboratorButton } from '@/components/billing/LimitGuards'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+
+interface CollaborationCardProps {
+  orgId: string
+  showId: string
+  orgSlug: string
+}
+
+export function CollaborationCard({ orgId, showId, orgSlug }: CollaborationCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Users className="h-4 w-4" />
+          Collaboration
+        </CardTitle>
+        <CardDescription>Invite partners and access advancing</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <InviteCollaboratorButton orgId={orgId} showId={showId} />
+        <Button asChild variant="outline" className="w-full justify-between">
+          <Link href={`/${orgSlug}/advancing`} className="flex w-full items-center justify-between">
+            <span>View Advancing Sessions</span>
+            <FileText className="h-4 w-4" />
+          </Link>
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/(app)/[org]/shows/[showId]/components/CollaboratorsCard.tsx
+++ b/app/(app)/[org]/shows/[showId]/components/CollaboratorsCard.tsx
@@ -1,0 +1,52 @@
+import { Mail } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+
+import type { CollaboratorRecord } from '../types'
+import { formatDateTime } from '../utils'
+
+interface CollaboratorsCardProps {
+  collaborators: CollaboratorRecord[]
+}
+
+export function CollaboratorsCard({ collaborators }: CollaboratorsCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Mail className="h-4 w-4" />
+          Collaborators
+        </CardTitle>
+        <CardDescription>Promoters and partners on this show</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {collaborators.length > 0 ? (
+          <ul className="space-y-3">
+            {collaborators.map((collaborator) => (
+              <li key={collaborator.id} className="rounded-md border border-muted bg-card/50 p-3">
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="text-sm font-medium text-foreground">{collaborator.email}</p>
+                  <Badge variant="outline" className="capitalize">
+                    {collaborator.role.replace('promoter_', '')}
+                  </Badge>
+                  <Badge variant="secondary" className="capitalize">
+                    {collaborator.status}
+                  </Badge>
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Invited {formatDateTime(collaborator.created_at)}
+                  {collaborator.accepted_at ? ` • Accepted ${formatDateTime(collaborator.accepted_at)}` : ''}
+                </p>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            No collaborators invited yet. Use the button above to bring promoters into the loop.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/(app)/[org]/shows/[showId]/components/CrewAssignmentsCard.tsx
+++ b/app/(app)/[org]/shows/[showId]/components/CrewAssignmentsCard.tsx
@@ -1,0 +1,44 @@
+import { Users } from 'lucide-react'
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+
+import type { AssignmentRecord } from '../types'
+
+interface CrewAssignmentsCardProps {
+  assignments: AssignmentRecord[]
+}
+
+export function CrewAssignmentsCard({ assignments }: CrewAssignmentsCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Users className="h-4 w-4" />
+          Crew Assignments
+        </CardTitle>
+        <CardDescription>Who&apos;s responsible for each role</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {assignments.length > 0 ? (
+          <ul className="space-y-3">
+            {assignments.map((assignment, index) => (
+              <li key={assignment.person?.id ?? index} className="rounded-md border border-muted bg-card/50 p-3">
+                <p className="text-sm font-medium text-foreground">{assignment.person?.name ?? 'Unassigned'}</p>
+                <p className="text-xs text-muted-foreground">
+                  {[assignment.duty, assignment.person?.role_title].filter(Boolean).join(' • ') || 'Role TBD'}
+                </p>
+                {(assignment.person?.email || assignment.person?.phone) && (
+                  <p className="text-xs text-muted-foreground">
+                    {[assignment.person?.email, assignment.person?.phone].filter(Boolean).join(' • ')}
+                  </p>
+                )}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-muted-foreground">Crew assignments haven&apos;t been added yet.</p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/(app)/[org]/shows/[showId]/components/ScheduleCard.tsx
+++ b/app/(app)/[org]/shows/[showId]/components/ScheduleCard.tsx
@@ -1,0 +1,47 @@
+import { Clock } from 'lucide-react'
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+
+import type { ScheduleItem } from '../types'
+import { formatScheduleRange } from '../utils'
+
+interface ScheduleCardProps {
+  items: ScheduleItem[]
+}
+
+export function ScheduleCard({ items }: ScheduleCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Clock className="h-4 w-4" />
+          Schedule
+        </CardTitle>
+        <CardDescription>Key times for the day</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {items.length > 0 ? (
+          <ul className="space-y-3">
+            {items.map((item) => (
+              <li key={item.id} className="rounded-md border border-muted bg-card/50 p-3">
+                <div className="flex flex-col gap-1">
+                  <p className="text-sm font-medium text-foreground">{item.title}</p>
+                  <p className="text-xs text-muted-foreground">{formatScheduleRange(item.starts_at, item.ends_at)}</p>
+                  {(item.location || item.notes) && (
+                    <p className="text-xs text-muted-foreground">
+                      {[item.location, item.notes].filter(Boolean).join(' • ')}
+                    </p>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            No schedule items yet. Add key timings to keep everyone aligned.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/(app)/[org]/shows/[showId]/components/ShowDetailHeader.tsx
+++ b/app/(app)/[org]/shows/[showId]/components/ShowDetailHeader.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+
+import type { ShowDetailRecord } from '../types'
+import { formatDate, statusLabel, statusVariant } from '../utils'
+
+interface ShowDetailHeaderProps {
+  orgSlug: string
+  show: ShowDetailRecord
+}
+
+export function ShowDetailHeader({ orgSlug, show }: ShowDetailHeaderProps) {
+  return (
+    <>
+      <Link
+        href={`/${orgSlug}/shows`}
+        className="inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to Shows
+      </Link>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="text-2xl font-semibold text-foreground">
+              {show.title ?? 'Untitled Show'}
+            </h1>
+            <Badge variant={statusVariant[show.status]}>{statusLabel[show.status]}</Badge>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {show.artist?.name ? `${show.artist.name} • ` : ''}
+            {formatDate(show.date)}
+          </p>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/app/(app)/[org]/shows/[showId]/components/ShowNotesCard.tsx
+++ b/app/(app)/[org]/shows/[showId]/components/ShowNotesCard.tsx
@@ -1,0 +1,24 @@
+import { FileText } from 'lucide-react'
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+
+interface ShowNotesCardProps {
+  notes: string
+}
+
+export function ShowNotesCard({ notes }: ShowNotesCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <FileText className="h-4 w-4" />
+          Notes
+        </CardTitle>
+        <CardDescription>Internal context for your team</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="whitespace-pre-line text-sm leading-relaxed text-foreground">{notes}</p>
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/(app)/[org]/shows/[showId]/components/ShowOverviewCard.tsx
+++ b/app/(app)/[org]/shows/[showId]/components/ShowOverviewCard.tsx
@@ -1,0 +1,88 @@
+import { CalendarDays, MapPin } from 'lucide-react'
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+
+import type { ShowDetailRecord, VenueContact } from '../types'
+import { formatDate, formatTime } from '../utils'
+
+interface ShowOverviewCardProps {
+  show: ShowDetailRecord
+  contacts: VenueContact[]
+}
+
+export function ShowOverviewCard({ show, contacts }: ShowOverviewCardProps) {
+  const locationLabel = show.venue?.city || show.venue?.country
+    ? [show.venue?.city, show.venue?.country].filter(Boolean).join(', ')
+    : 'TBD'
+  const capacityValue = show.venue?.capacity ?? null
+  const capacityLabel =
+    typeof capacityValue === 'number' && !Number.isNaN(capacityValue)
+      ? `${capacityValue.toLocaleString()} cap`
+      : 'Unknown'
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <CalendarDays className="h-4 w-4" />
+          Show Overview
+        </CardTitle>
+        <CardDescription>Key details for this performance</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <dl className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <dt className="text-xs uppercase text-muted-foreground">Date</dt>
+            <dd className="mt-1 text-sm font-medium text-foreground">{formatDate(show.date)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase text-muted-foreground">Venue</dt>
+            <dd className="mt-1 text-sm font-medium text-foreground">{show.venue?.name ?? 'TBD'}</dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase text-muted-foreground">Doors</dt>
+            <dd className="mt-1 text-sm font-medium text-foreground">{formatTime(show.doors_at)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase text-muted-foreground">Set Time</dt>
+            <dd className="mt-1 text-sm font-medium text-foreground">{formatTime(show.set_time)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase text-muted-foreground">Location</dt>
+            <dd className="mt-1 text-sm text-foreground">{locationLabel}</dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase text-muted-foreground">Capacity</dt>
+            <dd className="mt-1 text-sm text-foreground">{capacityLabel}</dd>
+          </div>
+        </dl>
+
+        {show.venue?.address && (
+          <div className="mt-6 flex items-start gap-2 text-sm text-muted-foreground">
+            <MapPin className="mt-0.5 h-4 w-4" />
+            <span>{show.venue.address}</span>
+          </div>
+        )}
+
+        {contacts.length > 0 && (
+          <div className="mt-6">
+            <h4 className="text-sm font-semibold text-foreground">Venue Contacts</h4>
+            <ul className="mt-3 space-y-2 text-sm">
+              {contacts.map((contact, index) => (
+                <li key={`${contact.email ?? contact.phone ?? index}`} className="flex flex-col">
+                  <span className="font-medium text-foreground">
+                    {contact.name ?? 'Contact'}
+                    {contact.role ? ` • ${contact.role}` : ''}
+                  </span>
+                  <span className="text-muted-foreground">
+                    {[contact.email, contact.phone].filter(Boolean).join(' • ') || 'No contact info'}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/(app)/[org]/shows/[showId]/page.tsx
+++ b/app/(app)/[org]/shows/[showId]/page.tsx
@@ -1,3 +1,58 @@
-export default function ShowDetailPage() {
-  return null
+import { unstable_noStore as noStore } from 'next/cache'
+import { notFound } from 'next/navigation'
+
+import { getSupabaseServer } from '@/lib/supabase/server'
+
+import { AdvancingSessionsCard } from './components/AdvancingSessionsCard'
+import { CollaborationCard } from './components/CollaborationCard'
+import { CollaboratorsCard } from './components/CollaboratorsCard'
+import { CrewAssignmentsCard } from './components/CrewAssignmentsCard'
+import { ScheduleCard } from './components/ScheduleCard'
+import { ShowDetailHeader } from './components/ShowDetailHeader'
+import { ShowNotesCard } from './components/ShowNotesCard'
+import { ShowOverviewCard } from './components/ShowOverviewCard'
+import { loadShowDetail } from './queries'
+
+interface ShowDetailPageProps {
+  params: { org: string; showId: string }
+}
+
+export default async function ShowDetailPage({ params }: ShowDetailPageProps) {
+  noStore()
+
+  const supabase = await getSupabaseServer()
+  const detail = await loadShowDetail({
+    supabase,
+    orgSlug: params.org,
+    showId: params.showId,
+  })
+
+  if (!detail) {
+    notFound()
+  }
+
+  const { org, show, scheduleItems, assignments, advancingSessions, collaborators, contacts } = detail
+
+  return (
+    <div className="mb-16 mt-4 space-y-6">
+      <ShowDetailHeader orgSlug={params.org} show={show} />
+
+      <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <ShowOverviewCard show={show} contacts={contacts} />
+        <CollaborationCard orgId={org.id} showId={show.id} orgSlug={params.org} />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <ScheduleCard items={scheduleItems} />
+        <CrewAssignmentsCard assignments={assignments} />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <AdvancingSessionsCard sessions={advancingSessions} orgSlug={params.org} />
+        <CollaboratorsCard collaborators={collaborators} />
+      </div>
+
+      {show.notes && <ShowNotesCard notes={show.notes} />}
+    </div>
+  )
 }

--- a/app/(app)/[org]/shows/[showId]/queries.ts
+++ b/app/(app)/[org]/shows/[showId]/queries.ts
@@ -1,0 +1,102 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import type { Database } from '@/lib/database.types'
+
+import { parseVenueContacts } from './utils'
+import type {
+  AdvancingSession,
+  AssignmentRecord,
+  CollaboratorRecord,
+  OrganizationSummary,
+  ScheduleItem,
+  ShowDetailData,
+  ShowDetailRecord,
+} from './types'
+
+type Supabase = SupabaseClient<Database>
+
+interface LoadShowDetailParams {
+  supabase: Supabase
+  orgSlug: string
+  showId: string
+}
+
+export async function loadShowDetail({
+  supabase,
+  orgSlug,
+  showId,
+}: LoadShowDetailParams): Promise<ShowDetailData | null> {
+  const { data: org } = await supabase
+    .from('organizations')
+    .select('id, name, slug')
+    .eq('slug', orgSlug)
+    .single<OrganizationSummary>()
+
+  if (!org) {
+    return null
+  }
+
+  const { data: show, error: showError } = await supabase
+    .from('shows')
+    .select(
+      `
+        id,
+        title,
+        status,
+        date,
+        doors_at,
+        set_time,
+        notes,
+        artist:artists ( id, name ),
+        venue:venues ( id, name, city, country, address, capacity, contacts )
+      `,
+    )
+    .eq('id', showId)
+    .eq('org_id', org.id)
+    .single<ShowDetailRecord>()
+
+  if (!show || showError) {
+    return null
+  }
+
+  const [scheduleRes, assignmentsRes, sessionsRes, collaboratorsRes] = await Promise.all([
+    supabase
+      .from('schedule_items')
+      .select('id, title, starts_at, ends_at, location, notes')
+      .eq('show_id', show.id)
+      .eq('org_id', org.id)
+      .order('starts_at', { ascending: true }),
+    supabase
+      .from('show_assignments')
+      .select('duty, person:people ( id, name, role_title, email, phone )')
+      .eq('show_id', show.id)
+      .order('duty', { ascending: true }),
+    supabase
+      .from('advancing_sessions')
+      .select('id, title, created_at, expires_at')
+      .eq('show_id', show.id)
+      .eq('org_id', org.id)
+      .order('created_at', { ascending: false }),
+    supabase
+      .from('show_collaborators')
+      .select('id, email, role, status, created_at, accepted_at')
+      .eq('show_id', show.id)
+      .eq('org_id', org.id)
+      .order('created_at', { ascending: true }),
+  ])
+
+  const scheduleItems = (scheduleRes.data ?? []) as ScheduleItem[]
+  const assignments = (assignmentsRes.data ?? []) as AssignmentRecord[]
+  const advancingSessions = (sessionsRes.data ?? []) as AdvancingSession[]
+  const collaborators = (collaboratorsRes.data ?? []) as CollaboratorRecord[]
+
+  return {
+    org,
+    show,
+    scheduleItems,
+    assignments,
+    advancingSessions,
+    collaborators,
+    contacts: parseVenueContacts(show.venue?.contacts ?? null),
+  }
+}

--- a/app/(app)/[org]/shows/[showId]/types.ts
+++ b/app/(app)/[org]/shows/[showId]/types.ts
@@ -1,0 +1,63 @@
+import type { Database } from '@/lib/database.types'
+
+export type ShowStatus = Database['public']['Enums']['show_status']
+
+export type OrganizationSummary = Pick<
+  Database['public']['Tables']['organizations']['Row'],
+  'id' | 'name' | 'slug'
+>
+
+export type ShowDetailRecord = Pick<
+  Database['public']['Tables']['shows']['Row'],
+  'id' | 'title' | 'status' | 'date' | 'doors_at' | 'set_time' | 'notes'
+> & {
+  artist: Pick<Database['public']['Tables']['artists']['Row'], 'id' | 'name'> | null
+  venue: Pick<
+    Database['public']['Tables']['venues']['Row'],
+    'id' | 'name' | 'city' | 'country' | 'address' | 'capacity' | 'contacts'
+  > | null
+}
+
+export type ScheduleItem = Pick<
+  Database['public']['Tables']['schedule_items']['Row'],
+  'id' | 'title' | 'starts_at' | 'ends_at' | 'location' | 'notes'
+>
+
+export type AssignmentRecord = Pick<
+  Database['public']['Tables']['show_assignments']['Row'],
+  'duty'
+> & {
+  person: Pick<
+    Database['public']['Tables']['people']['Row'],
+    'id' | 'name' | 'role_title' | 'email' | 'phone'
+  > | null
+}
+
+export type AdvancingSession = Pick<
+  Database['public']['Tables']['advancing_sessions']['Row'],
+  'id' | 'title' | 'created_at' | 'expires_at'
+>
+
+export type CollaboratorRecord = Pick<
+  Database['public']['Tables']['show_collaborators']['Row'],
+  'id' | 'email' | 'role' | 'status' | 'created_at' | 'accepted_at'
+>
+
+export type VenueContactsValue = Database['public']['Tables']['venues']['Row']['contacts']
+
+export type VenueContact = {
+  name?: string
+  role?: string
+  email?: string
+  phone?: string
+}
+
+export interface ShowDetailData {
+  org: OrganizationSummary
+  show: ShowDetailRecord
+  scheduleItems: ScheduleItem[]
+  assignments: AssignmentRecord[]
+  advancingSessions: AdvancingSession[]
+  collaborators: CollaboratorRecord[]
+  contacts: VenueContact[]
+}

--- a/app/(app)/[org]/shows/[showId]/utils.ts
+++ b/app/(app)/[org]/shows/[showId]/utils.ts
@@ -1,0 +1,89 @@
+import type { ShowStatus, VenueContact, VenueContactsValue } from './types'
+
+export const statusLabel: Record<ShowStatus, string> = {
+  confirmed: 'Confirmed',
+  draft: 'Draft',
+  cancelled: 'Cancelled',
+}
+
+export const statusVariant: Record<ShowStatus, 'default' | 'secondary' | 'destructive'> = {
+  confirmed: 'default',
+  draft: 'secondary',
+  cancelled: 'destructive',
+}
+
+export function formatDate(value: string) {
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      weekday: 'long',
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    }).format(new Date(`${value}T00:00:00Z`))
+  } catch {
+    return value
+  }
+}
+
+export function formatTime(value: string | null) {
+  if (!value) return 'TBD'
+
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+    }).format(new Date(value))
+  } catch {
+    return 'TBD'
+  }
+}
+
+export function formatDateTime(value: string) {
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    }).format(new Date(value))
+  } catch {
+    return value
+  }
+}
+
+export function formatScheduleRange(start: string, end: string | null) {
+  const startTime = formatDateTime(start)
+  if (!end) {
+    return startTime
+  }
+
+  try {
+    const endTime = new Intl.DateTimeFormat('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+    }).format(new Date(end))
+
+    return `${startTime} → ${endTime}`
+  } catch {
+    return startTime
+  }
+}
+
+export function parseVenueContacts(value: VenueContactsValue): VenueContact[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .filter((contact): contact is Record<string, unknown> =>
+      typeof contact === 'object' && contact !== null && !Array.isArray(contact),
+    )
+    .map((contact) => ({
+      name: typeof contact['name'] === 'string' ? (contact['name'] as string) : undefined,
+      role: typeof contact['role'] === 'string' ? (contact['role'] as string) : undefined,
+      email: typeof contact['email'] === 'string' ? (contact['email'] as string) : undefined,
+      phone: typeof contact['phone'] === 'string' ? (contact['phone'] as string) : undefined,
+    }))
+    .filter((contact) => Object.values(contact).some(Boolean))
+}

--- a/app/utils/supabase/server.ts
+++ b/app/utils/supabase/server.ts
@@ -1,5 +1,5 @@
 
-import { createServerClient, type CookieOptions } from '@supabase/ssr'
+import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 import { Database } from '@/lib/database.types'
 

--- a/components/billing/LimitGuards.tsx
+++ b/components/billing/LimitGuards.tsx
@@ -5,7 +5,7 @@ import { LimitCheck } from '@/lib/billing'
 import { checkOrgLimitsClient } from '@/lib/billing-client'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
-import { UserPlus, UserCheck, Crown, AlertTriangle } from 'lucide-react'
+import { UserPlus, UserCheck, Crown } from 'lucide-react'
 
 interface LimitGuardProps {
   orgId: string


### PR DESCRIPTION
## Summary
- refactor the show detail page to orchestrate data loading and render dedicated subcomponents
- introduce typed supabase-backed queries and shared utilities for formatting and venue contacts
- add focused cards for overview, collaboration, schedule, assignments, advancing sessions, collaborators, and notes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cc760d4648832799922c6173ebc55c